### PR TITLE
feat: behler-parrinnello symmetry functions G1-G5

### DIFF
--- a/meta_learn_force_fields/models/symmetry_functions.py
+++ b/meta_learn_force_fields/models/symmetry_functions.py
@@ -1,0 +1,122 @@
+import numpy as np
+import torch
+
+
+class RadialFunction(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        radials = 0.5 * \
+            (torch.cos(np.pi * distances / self.cutoff_radius) + 1)
+        return torch.where(distances <= self.cutoff_radius, radials, torch.zeros_like(distances))
+
+
+class AngularFunction(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, distance_vectors: torch.Tensor, distances: torch.Tensor) -> torch.Tensor:
+        dot_products = torch.einsum(
+            '...ijd,...jkd->...ijk', distance_vectors, distance_vectors)
+        magnitudes = torch.einsum(
+            '...ij,...jk->...ijk', distances, distances)
+        return dot_products / magnitudes
+
+
+class G1(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+
+        self.radial_function = RadialFunction(self.cutoff_radius)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        radials = self.radial_function(distances)
+        return radials.sum(dim=-1)
+
+
+class G2(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0, eta: float = 0.5):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+        self.eta = eta
+
+        self.radial_function = RadialFunction(self.cutoff_radius)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        exponential_term = torch.exp(-self.eta *
+                                     (distances - self.cutoff_radius) ** 2)
+        radial_term = self.radial_function(distances)
+        return (exponential_term * radial_term).sum(dim=-1)
+
+
+class G3(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0, kappa: float = 1.0):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+        self.kappa = kappa
+
+        self.radial_function = RadialFunction(self.cutoff_radius)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        cosine_term = torch.cos(self.kappa * distances)
+        radial_term = self.radial_function(distances)
+        return (cosine_term * radial_term).sum(dim=-1)
+
+
+class G4(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0, eta: float = 0.5, zeta: float = 1.0, lambda_: float = 1.0):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+        self.eta = eta
+        self.zeta = zeta
+        self.lambda_ = lambda_
+
+        self.radial_function = RadialFunction(self.cutoff_radius)
+        self.angular_function = AngularFunction()
+
+    def forward(self, distance_vectors: torch.Tensor, distances: torch.Tensor) -> torch.Tensor:
+        cosines = self.angular_function(distance_vectors, distances)
+        cosine_term = (1 + self.lambda_ * cosines) ** self.zeta
+        cosine_term = torch.nan_to_num(
+            cosine_term, nan=0.0, posinf=0.0, neginf=0.0)
+
+        exponent = torch.unsqueeze(distances, dim=-1) ** 2 + torch.unsqueeze(
+            distances, dim=-2) ** 2 + torch.unsqueeze(distances, dim=-3) ** 2
+        exponential_term = torch.exp(-self.eta * exponent)
+
+        radials = self.radial_function(distances)
+        radial_term = torch.unsqueeze(
+            radials, dim=-1) * torch.unsqueeze(radials, dim=-2) * torch.unsqueeze(radials, dim=-3)
+
+        return (cosine_term * exponential_term * radial_term).sum(dim=(-1, -2))
+
+
+class G5(torch.nn.Module):
+    def __init__(self, cutoff_radius: float = 5.0, eta: float = 0.5, zeta: float = 1.0, lambda_: float = 1.0):
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
+        self.eta = eta
+        self.zeta = zeta
+        self.lambda_ = lambda_
+
+        self.radial_function = RadialFunction(self.cutoff_radius)
+        self.angular_function = AngularFunction()
+
+    def forward(self, distance_vectors: torch.Tensor, distances: torch.Tensor) -> torch.Tensor:
+        cosines = self.angular_function(distance_vectors, distances)
+        cosine_term = (1 + self.lambda_ * cosines) ** self.zeta
+        cosine_term = torch.nan_to_num(
+            cosine_term, nan=0.0, posinf=0.0, neginf=0.0)
+
+        exponent = torch.unsqueeze(
+            distances, dim=-1) ** 2 + torch.unsqueeze(distances, dim=-2) ** 2
+        exponential_term = torch.exp(-self.eta * exponent)
+
+        radials = self.radial_function(distances)
+        radial_term = torch.unsqueeze(
+            radials, dim=-1) * torch.unsqueeze(radials, dim=-2)
+
+        return (cosine_term * exponential_term * radial_term).sum(dim=(-1, -2))


### PR DESCRIPTION
Implemented the following symmetry functions in PyTorch:

$$
f\left(R_{ij}\right) = \begin{cases}
\frac{1}{2} \left[\cos\left(\pi \cdot \frac{R_{ij}}{R_c}\right) + 1\right] & R_{ij} \leq R_c \\
0 & R_{ij} > R_c
\end{cases}
$$

$$
\cos\left(\theta_{ijk}\right) = \frac{\mathbf{R}_{ij} \cdot \mathbf{R}_{jk}}{R_{ij}R_{jk}}
$$

$$
G_i^1 = \sum_{j}f\left(R_{ij}\right)
$$

$$
G_i^2 = \sum_{j}\exp\left(-\eta(R_{ij} - R_s)^2 \right) \cdot f\left(R_{ij}\right)
$$

$$
G_i^3 = \sum_{j}\cos\left(\kappa R_{ij}\right)f\left(R_{ij}\right)
$$

$$
G_i^4 = \sum_{k \neq i}\sum_{j \neq i}\left(1 + \lambda\cos\left(\theta_{ijk}\right)\right)^\zeta\cdot\exp\left(-\eta(R_{ij}^2 + R_{ik}^2 + R_{jk}^2) \right) \cdot f\left(R_{ij}\right)  \cdot f\left(R_{ik}\right)  \cdot f\left(R_{jk}\right)
$$

$$
G_i^5 = \sum_{k \neq i}\sum_{j \neq i}\left(1 + \lambda\cos\left(\theta_{ijk}\right)\right)^\zeta\cdot\exp\left(-\eta(R_{ij}^2 + R_{ik}^2) \right) \cdot f\left(R_{ij}\right)  \cdot f\left(R_{ik}\right)
$$